### PR TITLE
Implement purging of old checklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ oldest ones (by modification date) first.
 Todos
 -----
 
-  * implement purging logic
   * use a smaller data structure to allow for using synced storage
 
     * key = checklist text, selected = true (only set checklist items that are in this blob)

--- a/code-review.conf.js
+++ b/code-review.conf.js
@@ -16,8 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       '*.js',
-      'tests/spec/*.js',
-      'tests/fixtures/*.html'
+      'tests/spec/*.js'
     ],
 
 
@@ -35,7 +34,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'verbose'],
+    reporters: ['progress'],
 
 
     // web server port

--- a/initUI.js
+++ b/initUI.js
@@ -15,8 +15,7 @@ function saveChecklist(event) {
     tabArray => {
       const tabUrl = tabArray[0].url;
 
-      storage.saveJsonInKey(json, tabUrl);
-      chrome.storage.local.het(storageObject);
+      storage.saveChecklist(json, tabUrl);
     }
   );
 }

--- a/master_template.json
+++ b/master_template.json
@@ -2,7 +2,22 @@
   "checklist": [
     {
       "name": "Commit messages conform to standards",
-      "description": "Well-formatted commit messages make it easy to quickly scan commit history and provide clear, concise information to the reader."
+      "description": "Well-formatted commit messages make it easy to scan commit history and provide clear, concise information to the reader."
+    },
+    {
+      "name": "All names are descriptive."
+    },
+    {
+      "name": "Items that use amounts encode the unit of measurement.",
+      "description": "A variable named something such as timeout_seconds requires less digging around to figure out the unit."
+    },
+    {
+      "name": "Public methods check the validity of all their arguments at the beginning of the method.",
+      "description": "Public methods have to act defensively and assume they'll get passed any range of garbage values. Checking early means that no state changes happen unless the input is all valid."
+    },
+    {
+      "name": "Storage that's appended to has a retention plan.",
+      "description": "If the code appends to some sort of storage, what is the retention policy for that data? Storage that grows and grows can cause operational headaches and system failures."
     },
     {
       "name": "Mutable data shared across threads is protected from concurrent modifications.",
@@ -11,13 +26,6 @@
     {
       "name": "Data is immutable wherever possible.",
       "description": "Data that is guaranteed to never change is thread-safe and easier to reason about when debugging."
-    },
-    {
-      "name": "Public methods check the validity of all their arguments at the beginning of the method.",
-      "description": "Public methods have to act defensively and assume they'll get passed any range of garbage values. Checking early means that no state changes happen unless the input is all valid."
-    },
-    {
-      "name": "All names are descriptive."
     },
     {
       "name": "Open connections are closed in the same place",

--- a/storage.js
+++ b/storage.js
@@ -10,7 +10,9 @@
  // ...
 const storage = {
 
-  EMPTY_CHECKLISTS: {checklists:[]},
+  INDEX_KEY: 'index',
+  CHECKLIST_KEY: 'checklists',
+  EMPTY_CHECKLISTS: {checklists:{}},
 
   /** Load the data for the given URL using the following sequence.
    *
@@ -23,8 +25,8 @@ const storage = {
    */
    loadChecklistForURL: function(url, checklistCallback) {
 
-     chrome.storage.local.get(url, checklistData => {
-       if (checklistData && checklistData[url] && checklistData[url].checklist) {
+     storage.getStorageArea().get(url, checklistData => {
+       if (storage.isValidChecklistObject(checklistData, url)) {
          checklistCallback(checklistData[url]);
        } else {
          fetch(chrome.extension.getURL('master_template.json')).then(
@@ -33,14 +35,153 @@ const storage = {
      })
    },
 
-   /** Saves the specified json into the specified key.
+   /** Determine if the passed in data is valid and has the given key
     *
-    * @param {Object} json data to save
+    * @param {Object} data the data blob to inspect
+    * @param {String} key the key to check
+    * @return {Boolean} whether the rest of the code can make assumptions about it
+    */
+    isObjectValid: function(objectToCheck, key) {
+      return objectToCheck != undefined && objectToCheck[key] != undefined
+    },
+
+    /** Determine if the given object is a valid stored checklist object.
+     *  In order to be considered valid, it needs to have the given url as a field
+     *  and that field must have a checklist property within it.
+     *
+     * @param {Object} objectToCheck to evaluate
+     * @param {String} url to use for evaluation
+     * @return {Boolean} if this is a valid checklist item
+     */
+    isValidChecklistObject: function(objectToCheck, url) {
+      return storage.isObjectValid(objectToCheck, url) && storage.isObjectValid(objectToCheck[url], 'checklist');
+    },
+
+    /** Determine if the passed-in object is a valid index object
+     *  There needs to be an index element with a checklists subelement
+     *  @param {Object} objectToCheck
+     *  @return {Boolean} if the object was a valid index
+     */
+    isValidIndexObject: function(objectToCheck) {
+      return storage.isObjectValid(objectToCheck,storage.INDEX_KEY) && storage.isObjectValid(objectToCheck[storage.INDEX_KEY], storage.CHECKLIST_KEY);
+    },
+
+   /** Saves the specified checklist into the specified key.
+    *
+    * @param {Object} checklist data to save
     * @param {String} storageKey the key in which to save the json
     */
-    saveJsonInKey: function(json, storageKey) {
+    saveChecklist: function(checklist, storageKey) {
+      if (!(checklist || storageKey)) {
+        return;
+      }
       const storageObject = {};
-      storageObject[storageKey] = json;
-      chrome.storage.local.set( storageObject);
-    }
+      storageObject[storageKey] = checklist;
+      storage.getStorageArea().set(storageObject, () => {
+
+        if (storage.errorOccurred()) {
+          storage.purgeAndRetry(checklist, storageKey);
+        } else {
+          storage.updateIndex(storageKey);
+        }
+
+      });
+    },
+
+    /** Updates the index for the given checklist. The index is maintained as a way
+     * to contain information about the storage as a whole.
+     *
+     * @param {String} storageKey the storageKey to update
+     */
+     updateIndex: function(storageKey) {
+       if (!storageKey) {
+         return
+       }
+       const indexEntry = {last_updated_timestamp: Date.now()};
+
+       storage.getStorageArea().get(storage.INDEX_KEY, index => {
+
+         if (storage.isValidIndexObject(index)) {
+           // update the existing list and re-save
+           index[storage.INDEX_KEY].checklists[storageKey] = indexEntry;
+           storage.getStorageArea().set(index);
+         } else {
+           // the index doesn't exist, so create it with this as the first entry
+           newIndex = {};
+           newIndex[storage.INDEX_KEY] = storage.EMPTY_CHECKLISTS;
+
+           newIndex[storage.INDEX_KEY].checklists[storageKey] = indexEntry;
+           storage.getStorageArea().set(newIndex);
+
+         }
+       });
+     },
+
+     /** Some error happened  when saving the checklist, so we need to purge
+      *  old checklists and try again.
+      *
+      * @param {Object} objectToSave the object to save
+      * @param {String} storageKey the key to store the data under
+      */
+      purgeAndRetry: function(objectToSave, storageKey) {
+
+        // get the index and work off of that
+        storage.getStorageArea().get(storage.INDEX_KEY, index => {
+
+          // figure out the item with the oldest timestamp
+          const indexItems = storage.convertIndexObjectToArray(index[storage.INDEX_KEY].checklists);
+          const oldestKey = storage.getOldestKeyInChecklists(indexItems);
+          storage.getStorageArea().remove(oldestKey, () => {
+             // only remove the checklist index entry if there were no errors
+             // otherwise, if you removed the index item but not the actual checklist
+             // you could orphan checklists
+             if (!storage.errorOccurred()) {
+                delete index[storage.INDEX_KEY].checklists[storageKey];
+                storage.getStorageArea().set(index);
+             }
+
+             // and now retry
+             storage.saveChecklist(objectToSave, storageKey);
+
+          });
+        });
+      },
+
+    /** Convert an index object's keys into an array of items where checklistKey is the object key and last_updated_timestamp is the teimstamp field.
+     *  @param {Object} checklistItems object containing checklist keys and timestamps
+     *  @return {Array} collated data where each element has a checklistKey field and a timestamp field
+     */
+     convertIndexObjectToArray: function(checklistItems) {
+       if (!checklistItems) {
+         return [];
+       }
+       return Object.keys(checklistItems).map( (key, _index) => ({checklistKey: key, timestamp: checklistItems[key].last_updated_timestamp}));
+     },
+
+    /** Find the oldest key in the array of checklists.
+     *  @param {Array} checklistIndexItems the index of checklist items
+     *  @return {String} the oldest item in the array; the one with the lowest timestamp
+     */
+     getOldestKeyInChecklists: function(checklistIndexItems) {
+       if (!checklistIndexItems) {
+         return undefined;
+       }
+       checklistIndexItems.sort( (left, right) => left.timestamp <= right.timestamp ? -1 : 1);
+       return checklistIndexItems[0].checklistKey;
+      },
+
+      /** Return whether there was an error or not in the last chrome operation.
+       *  @return {Boolean} whether chrome.runtime.lasterror is set
+       */
+       errorOccurred: function() {
+         return chrome.runtime.lastError != undefined;
+       },
+
+     /** Returns the storage engine used by the extension.
+      *
+      * @return {Object} Chrome StorageArea
+      */
+      getStorageArea: function() {
+        return chrome.storage.local;
+      }
 }

--- a/tests/spec/Storage.js
+++ b/tests/spec/Storage.js
@@ -1,0 +1,46 @@
+describe('object validity tests', () => {
+
+  describe('isObjectValid', () => {
+    const testKey = 'test';
+
+    it ('considers undefined to be invalid', () => {
+      expect(storage.isObjectValid(undefined, testKey)).toBe(false);
+    });
+
+    it ('considers an object without the given key invalid', () => {
+      const testObject = {}
+      expect(storage.isObjectValid(testObject, testKey)).toBe(false);
+    });
+
+    it ('considers an object with the given key to be valid', () => {
+      const testObject = {};
+      testObject[testKey] = 'response';
+      expect(storage.isObjectValid(testObject, testKey)).toBe(true);
+    });
+  });
+});
+
+describe('utility functions', () => {
+
+  it ('should find the oldest checklist', () => {
+    const testArray = [
+      {checklistKey: "abcd", timestamp: 1000},
+      {checklistKey: "defg", timestamp: 100},
+      {checklistKey: "zywx", timestamp: 1}
+    ];
+
+    const oldestKey = storage.getOldestKeyInChecklists(testArray);
+    expect(oldestKey).toBe('zywx');
+  });
+
+  it ('should collate an index of checklist items properly', () => {
+    const testObject = { checklists:{
+      abc: {last_updated_timestamp: 123},
+      def: {last_updated_timestamp: 456}
+    }};
+
+    const coalescedItems = storage.convertIndexObjectToArray(testObject.checklists);
+    expect(coalescedItems[0].checklistKey).toBe('abc');
+    expect(coalescedItems[0].timestamp).toBe(123);;
+  });
+});


### PR DESCRIPTION
If any error is detected when saving a checklist,
the code will purge old items and then retry. It keeps track of
checklist modification time in a separate index that can
be quickly inspected.

Also adds checklist items relevant to this code.